### PR TITLE
Handle grade and subject indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
 # Hocam
+
+Bu proje, PDF dosyalarından Türkçe metin çıkararak FAISS vektör veritabanına kaydeden ve dil modeli ile sorulara cevap veren bir Streamlit uygulamasıdır.
+
+## Kurulum
+
+```bash
+pip install -r requirements.txt
+```
+
+Python 3.8+ gereklidir. Tüm bağımlılıklar kurulduktan sonra ilk çalıştırmada gerekli modeller Hugging Face üzerinden indirilerek `~/.cache/huggingface` klasörüne kaydedilir. Bu indirme işlemini ilk çalıştırmadan önce yapmak isterseniz aşağıdaki komutu çalıştırabilirsiniz:
+
+```bash
+python - <<'PY'
+from transformers import AutoTokenizer, AutoModel
+for model in [
+    "dbmdz/gpt2-turkish",
+    "AI4Turk/ke-t5-small-tr",
+    "cahya/gpt2-small-turkish",
+    "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+]:
+    AutoTokenizer.from_pretrained(model)
+    AutoModel.from_pretrained(model)
+PY
+```
+
+Bu sayede uygulama çevrimdışı ortamlarda da çalıştırılabilir.
+
+## Kullanım
+
+```bash
+streamlit run app.py
+```
+
+Arayüzde önce sınıf ve ders seçimi yaparak PDF yükleyip **İndeks Oluştur** butonuna basın. Sorularınızı yazıp **Cevapla** butonu ile yanıtları görebilirsiniz. Her sınıf ve ders için ayrı `index/`, `embeddings/` ve `chunks/` klasörlerinde dosyalar tutulur.
+
+### Özellikler
+
+- PDF yüklemeden soru sorulmaya çalışıldığında kullanıcıya kısa bir uyarı gösterilir.
+- `Model seç` menüsünden GPT-2 veya T5 tabanlı Türkçe modelleri seçebilirsiniz.
+- Seçilen modelin türü otomatik algılanır ve uygun şekilde yüklenir.
+- GPU varsa modeller otomatik olarak GPU'ya taşınır.
+- Arama sonuçları ilk 10 parça içinden yeniden sıralanarak en alakalı 3 parça kullanılır.
+- Tüm veriler yerel dizinde saklandığı için uygulama internet bağlantısı olmadan da çalışabilir.
+- Her sınıf ve ders için ayrı indeks dosyaları tutulur.
+- İngilizce dersinde kelime bazlı sorular için Türkçe açıklamalı özel yanıt verilir.
+- PDF metinleri artık tokenizer kullanılarak token bazlı parçalara ayrılır.
+- ``extract_chunks`` fonksiyonu embedding modelinin tokenizer'ını
+  kullanacak şekilde güncellenmiştir ve parçalara üst üste binme
+  (``chunk_overlap``) ekleme seçeneği sunar.
+- Sesli soru sorma ve gTTS ile sesli yanıt alma desteği eklenmiştir.
+- Kullanıcı adı ile giriş yapıldığında öğrenci puan kazanır, veliler puan tablosunu görüntüler.
+- Puanlar basit bir SQLite veritabanında saklanır.
+- Embedding modeli varsayılan olarak `paraphrase-multilingual-MiniLM-L12-v2` kullanır, `bert-base-turkish-cased` ile değiştirmek mümkündür.

--- a/answer_generator.py
+++ b/answer_generator.py
@@ -1,0 +1,73 @@
+from typing import List
+from english_helper import get_word_info
+from transformers import (
+    AutoModelForCausalLM,
+    AutoModelForSeq2SeqLM,
+    AutoTokenizer,
+    AutoConfig,
+)
+import torch
+
+
+class AnswerGenerator:
+    def __init__(self, model_name: str = "cahya/gpt2-small-turkish", cache_dir: str = None):
+        """Load the model (Seq2Seq or CausalLM) and move it to the available device."""
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=cache_dir)
+        config = AutoConfig.from_pretrained(model_name, cache_dir=cache_dir)
+        if getattr(config, "is_encoder_decoder", False):
+            self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name, cache_dir=cache_dir)
+            self.is_seq2seq = True
+        else:
+            self.model = AutoModelForCausalLM.from_pretrained(model_name, cache_dir=cache_dir)
+            self.is_seq2seq = False
+        self.model.to(self.device)
+        self.model.eval()
+
+    def generate(
+        self,
+        context_chunks: List[str],
+        question: str,
+        grade: int = 1,
+        subject: str = "Türkçe",
+        max_length: int = 150,
+    ) -> str:
+        """Generate an answer using the provided context."""
+        context = "\n".join(context_chunks)
+
+        # Special handling for English words
+        if subject == "İngilizce":
+            word_info = get_word_info(question.strip())
+            if word_info:
+                if grade <= 4:
+                    return word_info + " \U0001F60A"
+                return word_info
+
+        if subject == "İngilizce":
+            prompt = (
+                f"{context}\n\nSoru: {question}\nCevap Türkçe ver. "
+                "Kelimenin anlamını, örnek cümle ve telaffuz ipucu ekle."
+            )
+        else:
+            prompt = f"{context}\n\nSoru: {question}\nCevap:"
+        inputs = self.tokenizer(prompt, return_tensors="pt")
+        inputs = {k: v.to(self.device) for k, v in inputs.items()}
+        with torch.no_grad():
+            outputs = self.model.generate(
+                **inputs,
+                max_length=inputs["input_ids"].shape[1] + max_length,
+                do_sample=True,
+                top_p=0.95,
+                top_k=50,
+            )
+        answer = self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+        if not self.is_seq2seq:
+            answer = answer.split("Cevap:")[-1]
+        return self._format_answer(answer.strip(), grade)
+
+    @staticmethod
+    def _format_answer(answer: str, grade: int) -> str:
+        """Format answer according to grade level."""
+        if grade <= 4:
+            return f"{answer} \U0001F44D"
+        return answer

--- a/app.py
+++ b/app.py
@@ -1,0 +1,136 @@
+import os
+import pickle
+import streamlit as st
+import numpy as np
+
+from speech_utils import text_to_speech, speech_to_text
+from score_db import init_db, add_user, add_points, get_scores
+
+from pdf_utils import extract_chunks
+from embedder import Embedder
+from search import VectorSearch
+from answer_generator import AnswerGenerator
+
+def make_paths(grade: int, subject: str):
+    subj = subject.lower().replace(" ", "_")
+    os.makedirs("index", exist_ok=True)
+    os.makedirs("chunks", exist_ok=True)
+    os.makedirs("embeddings", exist_ok=True)
+    index_path = os.path.join("index", f"{grade}_{subj}.index")
+    chunk_path = os.path.join("chunks", f"{grade}_{subj}.pkl")
+    emb_path = os.path.join("embeddings", f"{grade}_{subj}.npy")
+    return index_path, chunk_path, emb_path
+
+
+def load_chunks(chunk_path: str):
+    if os.path.exists(chunk_path):
+        with open(chunk_path, "rb") as f:
+            return pickle.load(f)
+    return None
+
+
+def load_embeddings(emb_path: str):
+    if os.path.exists(emb_path):
+        return np.load(emb_path)
+    return None
+
+
+def save_embeddings(embeddings, emb_path: str):
+    np.save(emb_path, embeddings)
+
+
+def save_chunks(chunks, chunk_path: str):
+    with open(chunk_path, "wb") as f:
+        pickle.dump(chunks, f)
+
+
+init_db()
+
+st.title("Türkçe Soru-Cevap Uygulaması")
+st.markdown(
+    "PDF yükleyip indeks oluşturduktan sonra sorularınızı yazabilirsiniz."
+)
+
+if "user" not in st.session_state:
+    name = st.text_input("Kullanıcı adı")
+    role = st.selectbox("Rol", ["Öğrenci", "Veli"])
+    if st.button("Giriş") and name:
+        st.session_state["user"] = name
+        st.session_state["role"] = role
+        add_user(name)
+        st.experimental_rerun()
+    st.stop()
+
+user = st.session_state["user"]
+role = st.session_state["role"]
+st.sidebar.write(f"Giriş yapan: {user} ({role})")
+
+if role == "Veli":
+    st.header("Puan Tablosu")
+    for name, pts in get_scores():
+        st.write(f"{name}: {pts}")
+    st.stop()
+
+grade = st.selectbox("Sınıf", list(range(1, 9)))
+subject = st.selectbox(
+    "Ders",
+    ["Türkçe", "Matematik", "Fen", "Sosyal", "Hayat Bilgisi", "İngilizce"],
+)
+
+index_path, chunk_path, emb_path = make_paths(grade, subject)
+
+embedder = Embedder()
+chunks = load_chunks(chunk_path)
+embeddings = load_embeddings(emb_path)
+dim = embeddings.shape[1] if embeddings is not None else 384
+vs = VectorSearch(dim=dim, grade=grade, subject=subject)
+
+if chunks is None:
+    st.info("Lütfen bir PDF yükleyin ve indeks oluşturun.")
+    uploaded = st.file_uploader("PDF Dosyası")
+    if uploaded and st.button("İndeks Oluştur"):
+        pdf_path = "uploaded.pdf"
+        with open(pdf_path, "wb") as f:
+            f.write(uploaded.read())
+        chunks = extract_chunks(pdf_path, tokenizer_name=embedder.model_name)
+        save_chunks(chunks, chunk_path)
+        embeddings = embedder.encode_texts(chunks)
+        save_embeddings(embeddings, emb_path)
+        vs.add_embeddings(embeddings)
+        st.success("İndeks kaydedildi.")
+
+question = st.text_input("Sorunuzu yazın")
+audio = st.file_uploader("Sesli soru (isteğe bağlı)", type=["wav", "mp3"])
+model_choice = st.selectbox(
+    "Model seç",
+    [
+        "dbmdz/gpt2-turkish",
+        "AI4Turk/ke-t5-small-tr",
+        "cahya/gpt2-small-turkish",
+    ],
+)
+
+if st.button("Cevapla"):
+    if not question and not audio:
+        st.warning("Lütfen bir soru girin veya ses yükleyin.")
+    elif chunks is None:
+        st.error("Önce bir PDF yükleyin ve indeks oluşturun.")
+    else:
+        if audio:
+            audio_path = "temp_audio"
+            with open(audio_path, "wb") as f:
+                f.write(audio.read())
+            question = speech_to_text(audio_path)
+            st.info(f"Algılanan soru: {question}")
+        query_vec = embedder.encode_query(question)
+        if embeddings is not None:
+            _, indices = vs.search_with_rerank(query_vec, embeddings, top_k=3)
+        else:
+            _, indices = vs.search(query_vec, top_k=3)
+        selected = [chunks[i] for i in indices if i < len(chunks)]
+        generator = AnswerGenerator(model_name=model_choice)
+        answer = generator.generate(selected, question, grade=grade, subject=subject)
+        st.markdown(f"**Cevap:**\n\n{answer}")
+        audio_out = text_to_speech(answer)
+        st.audio(audio_out)
+        add_points(user)

--- a/embedder.py
+++ b/embedder.py
@@ -1,0 +1,22 @@
+from typing import List
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+
+class Embedder:
+    def __init__(
+        self,
+        model_name: str = "paraphrase-multilingual-MiniLM-L12-v2",
+        cache_dir: str = None,
+    ):
+        """Load SentenceTransformer model.``model_name`` can be changed to
+        ``bert-base-turkish-cased`` for experimental Turkish embeddings."""
+
+        self.model_name = model_name
+        self.model = SentenceTransformer(model_name, cache_folder=cache_dir)
+
+    def encode_texts(self, texts: List[str]) -> np.ndarray:
+        return np.array(self.model.encode(texts, show_progress_bar=True, convert_to_numpy=True))
+
+    def encode_query(self, query: str) -> np.ndarray:
+        return self.model.encode([query], convert_to_numpy=True)[0]

--- a/english_helper.py
+++ b/english_helper.py
@@ -1,0 +1,52 @@
+WORDS = {
+    "cat": {
+        "meaning": "kedi",
+        "example": "The cat is sleeping on the sofa.",
+        "pronunciation": "kæt",
+    },
+    "run": {
+        "meaning": "koşmak",
+        "example": "I like to run every morning.",
+        "pronunciation": "rʌn",
+    },
+    "school": {
+        "meaning": "okul",
+        "example": "We go to school five days a week.",
+        "pronunciation": "skuːl",
+    },
+    "table": {
+        "meaning": "masa",
+        "example": "He put the books on the table.",
+        "pronunciation": "ˈteɪb(ə)l",
+    },
+    "book": {
+        "meaning": "kitap",
+        "example": "This book is very interesting.",
+        "pronunciation": "bʊk",
+    },
+    "computer": {
+        "meaning": "bilgisayar",
+        "example": "The computer is on the desk.",
+        "pronunciation": "kəmˈpjuːtə",
+    },
+    "dog": {
+        "meaning": "köpek",
+        "example": "The dog barked loudly.",
+        "pronunciation": "dɒg",
+    },
+    "happy": {
+        "meaning": "mutlu",
+        "example": "She feels happy today.",
+        "pronunciation": "ˈhæpi",
+    },
+}
+
+def get_word_info(word: str) -> str:
+    info = WORDS.get(word.lower())
+    if not info:
+        return None
+    return (
+        f"**{word}** anlamı **{info['meaning']}**.\n"
+        f"Örnek: {info['example']}\n"
+        f"Telaffuz: /{info['pronunciation']}/"
+    )

--- a/pdf_utils.py
+++ b/pdf_utils.py
@@ -1,0 +1,29 @@
+import os
+from typing import List
+from PyPDF2 import PdfReader
+from transformers import AutoTokenizer
+
+
+def extract_chunks(
+    pdf_path: str,
+    chunk_size: int = 100,
+    tokenizer_name: str = "dbmdz/gpt2-turkish",
+    chunk_overlap: int = 0,
+) -> List[str]:
+    """Extract text from PDF and split into token-based chunks."""
+    if not os.path.exists(pdf_path):
+        raise FileNotFoundError(f"PDF not found: {pdf_path}")
+
+    reader = PdfReader(pdf_path)
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+    chunks = []
+    for page in reader.pages:
+        text = page.extract_text() or ""
+        tokens = tokenizer.encode(text, add_special_tokens=False)
+        step = max(chunk_size - chunk_overlap, 1)
+        for i in range(0, len(tokens), step):
+            piece = tokens[i : i + chunk_size]
+            chunk = tokenizer.decode(piece)
+            if chunk.strip():
+                chunks.append(chunk.strip())
+    return chunks

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+streamlit
+PyPDF2
+sentence-transformers
+faiss-cpu
+transformers
+torch
+gTTS
+openai-whisper

--- a/score_db.py
+++ b/score_db.py
@@ -1,0 +1,39 @@
+import sqlite3
+
+DB_PATH = "scores.db"
+
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        "CREATE TABLE IF NOT EXISTS scores (name TEXT PRIMARY KEY, points INTEGER)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def add_user(name: str):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute("INSERT OR IGNORE INTO scores (name, points) VALUES (?, 0)", (name,))
+    conn.commit()
+    conn.close()
+
+
+def add_points(name: str, points: int = 1):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute("INSERT OR IGNORE INTO scores (name, points) VALUES (?, 0)", (name,))
+    c.execute("UPDATE scores SET points = points + ? WHERE name = ?", (points, name))
+    conn.commit()
+    conn.close()
+
+
+def get_scores():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute("SELECT name, points FROM scores ORDER BY points DESC")
+    rows = c.fetchall()
+    conn.close()
+    return rows

--- a/search.py
+++ b/search.py
@@ -1,0 +1,45 @@
+import os
+from typing import List, Tuple
+import numpy as np
+import faiss
+
+
+class VectorSearch:
+    def __init__(
+        self,
+        dim: int,
+        grade: int,
+        subject: str,
+        base_dir: str = "index",
+    ):
+        os.makedirs(base_dir, exist_ok=True)
+        subject_safe = subject.lower().replace(" ", "_")
+        self.index_path = os.path.join(base_dir, f"{grade}_{subject_safe}.index")
+        if os.path.exists(self.index_path):
+            self.index = faiss.read_index(self.index_path)
+        else:
+            self.index = faiss.IndexFlatL2(dim)
+
+    def add_embeddings(self, embeddings: np.ndarray):
+        self.index.add(embeddings)
+        faiss.write_index(self.index, self.index_path)
+
+    def search(self, query_vec: np.ndarray, top_k: int = 3) -> Tuple[np.ndarray, np.ndarray]:
+        distances, indices = self.index.search(query_vec.reshape(1, -1), top_k)
+        return distances[0], indices[0]
+
+    def search_with_rerank(
+        self,
+        query_vec: np.ndarray,
+        embeddings: np.ndarray,
+        top_k: int = 3,
+        search_k: int = 10,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Search top ``search_k`` then re-rank by cosine similarity."""
+        dist, idx = self.index.search(query_vec.reshape(1, -1), search_k)
+        candidates = embeddings[idx[0]]
+        sims = np.dot(candidates, query_vec) / (
+            np.linalg.norm(candidates, axis=1) * np.linalg.norm(query_vec) + 1e-8
+        )
+        order = np.argsort(-sims)[:top_k]
+        return sims[order], idx[0][order]

--- a/speech_utils.py
+++ b/speech_utils.py
@@ -1,0 +1,20 @@
+from gtts import gTTS
+import tempfile
+import whisper
+import os
+
+
+def text_to_speech(text: str) -> str:
+    """Convert text to speech and return path to mp3 file."""
+    tts = gTTS(text, lang="tr")
+    fd, path = tempfile.mkstemp(suffix=".mp3")
+    os.close(fd)
+    tts.save(path)
+    return path
+
+
+def speech_to_text(audio_path: str, model_size: str = "base") -> str:
+    """Transcribe Turkish audio using Whisper."""
+    model = whisper.load_model(model_size)
+    result = model.transcribe(audio_path, language="tr")
+    return result.get("text", "").strip()


### PR DESCRIPTION
## Summary
- manage separate indexes by grade and subject with helper function
- add grade and lesson selection UI controls
- implement English word helper and grade-based formatting
- adjust vector search paths
- document new behaviour
- chunk text with tokenizer
- add voice support and simple scoring system
- tweak chunk extraction to use embedding tokenizer and allow overlap

## Testing
- `python3 -m py_compile *.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866467d0034832d9f11b18f5ee69fe5